### PR TITLE
Fixing default value for sumologic.sourceCategoryPrefix

### DIFF
--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.sourceName` | Set the sumo `_sourceName` | `%{namespace}.%{pod}.%{container}` |
 | `sumologic.sourceHost` | Set the sumo `_sourceHost` | `Nil` |
 | `sumologic.sourceCategory` | Set the sumo `_sourceCategory` | `%{namespace}/%{pod_name}` |
-| `sumologic.sourceCategoryPrefix` | Define a prefix, for `_sourceCategory` | `Nil` |
+| `sumologic.sourceCategoryPrefix` | Define a prefix, for `_sourceCategory` | `kubernetes/` |
 | `sumologic.sourceCategoryReplaceDash` | Used to replace `-` with another character | `/` |
 | `sumologic.logFormat` | Format to post logs, into sumo (`json`, `json_merge`, or `text`) | `json` |
 | `sumologic.kubernetesMeta` | Include or exclude kubernetes metadata, with `json` format | `true` |


### PR DESCRIPTION
From my (limited) use of the chart, it seems like this should be the true default value.  If I don't specify this value all source categories start with "kubernetes/"  But if I supply something, the "kubernetes/" is not there anymore.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fixing a potentially incorrect documentation element.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

From my experience using the chart it seems like this default value is incorrect in the documentation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Variables are documented in the README.md
